### PR TITLE
Don't break on abbreviations like i.e. or e.g.

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -51,7 +51,7 @@ module.exports =
             if foundPeriod
               wrapNext = true
             # wrap next segment if this contains a strong delimiter
-            if /(\.|\?|\!|\:|\;|\])$/.test(segment) and not insideComment
+            if /(\w{2,}\.|\?|\!|\:|\;|\])$/.test(segment) and not insideComment
               foundPeriod = true
             # wrap next segment if this contains a weak delimiter and is past half
             # the length of the line

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -51,7 +51,7 @@ module.exports =
             if foundPeriod
               wrapNext = true
             # wrap next segment if this contains a strong delimiter
-            if /(\w{2,}\.|\?|\!|\:|\;|\])$/.test(segment) and not insideComment
+            if /(\w{2,}\.|\}\.|\?|\!|\:|\;|\])$/.test(segment) and not insideComment
               foundPeriod = true
             # wrap next segment if this contains a weak delimiter and is past half
             # the length of the line


### PR DESCRIPTION
Only break on periods if they are preceded by at least two word characters.

**Example**

Input:
```
Only use these abbreviated forms e.g. and i.e. in more informal or expedient documents. It's taken care of. So that is good.
```

Old behavior:
```
Only use these abbreviated forms e.g.
and i.e.
in more informal or expedient documents.
It's taken care of.
So that is good.
```

New behavior:
```
Only use these abbreviated forms e.g. and i.e. in more informal or expedient
documents.
It's taken care of.
So that is good.
```